### PR TITLE
Nominate Stefan Karschti as MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -152,6 +152,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@smellyshovel](https://github.com/smellyshovel)
 
+[@stefankarschti](https://github.com/stefankarschti)
+
 [@stefanschaller](https://github.com/stefanschaller) (tapped.dev)
 
 [@stuartlynn](https://github.com/stuartlynn) (University of Chicago)


### PR DESCRIPTION
I would like to nominate @stefankarschti to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->

Stefan has been instrumental in implementing the Metal backend for MapLibre Native.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [ ] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
